### PR TITLE
Add oracle price feed to the chart

### DIFF
--- a/components/Chart/Chart.tsx
+++ b/components/Chart/Chart.tsx
@@ -1,5 +1,3 @@
-import { CHART_FEED_QUERY } from '@/requests/queries';
-import { ChartFeedResponse } from '@/types/chartTypes';
 import { useQuery } from '@apollo/client';
 import { useAtom } from 'jotai';
 import React, { useEffect, useRef, useState } from 'react';
@@ -13,10 +11,11 @@ import { chosenMarketAtom } from '@/store/store';
 import Image from 'next/image';
 
 interface ChartProps {
-  data: { time: UTCTimestamp; value: number }[];
+  marketPriceData: { time: UTCTimestamp; value: number }[];
+  oraclePriceData: { time: UTCTimestamp; value: number }[];
 }
 
-export const Chart = ({ data }: ChartProps) => {
+export const Chart = ({ marketPriceData, oraclePriceData }: ChartProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [chosenMarket] = useAtom(chosenMarketAtom);
@@ -68,9 +67,32 @@ export const Chart = ({ data }: ChartProps) => {
             vertLines: { color: '#444650' },
           }}
           layout={{ background: { color: '#191B24' }, textColor: 'white' }}
+          timeScale={{
+            timeVisible: true,
+            secondsVisible: true,
+            tickMarkFormatter: (time: any, tickMarkType: any, locale: any) => {
+              const date = new Date(time * 1000);
+              const hours = date.getHours().toString().padStart(2, '0');
+              const minutes = date.getMinutes().toString().padStart(2, '0');
+              const seconds = date.getSeconds().toString().padStart(2, '0');
+
+              if (tickMarkType === 'second') {
+                return `${hours}:${minutes}:${seconds}`;
+              } else if (tickMarkType === 'minute') {
+                return `${hours}:${minutes}`;
+              } else if (tickMarkType === 'hour') {
+                return `${hours}:00`;
+              } else {
+                return date.toLocaleDateString(locale);
+              }
+            },
+          }}
         >
-          {data.length > 0 && (
-            <LineSeries data={data} reactive color={'#4ECB7D'} />
+          {marketPriceData.length > 0 && (
+            <LineSeries data={marketPriceData} reactive color={'#4ECB7D'} />
+          )}
+          {oraclePriceData.length > 0 && (
+            <LineSeries data={oraclePriceData} reactive color={'#ffc0cb'} />
           )}
         </ChartComponent>
       )}

--- a/components/Chart/Chart.tsx
+++ b/components/Chart/Chart.tsx
@@ -19,6 +19,8 @@ export const Chart = ({ marketPriceData, oraclePriceData }: ChartProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [chosenMarket] = useAtom(chosenMarketAtom);
+  const [marketPriceDisplay, setMarketPriceDisplay] = useState<boolean>(true);
+  const [oraclePriceDisplay, setOraclePriceDisplay] = useState<boolean>(false);
   useEffect(() => {
     const updateDimensions = () => {
       if (containerRef.current) {
@@ -36,6 +38,19 @@ export const Chart = ({ marketPriceData, oraclePriceData }: ChartProps) => {
       window.removeEventListener('resize', updateDimensions);
     };
   }, []);
+
+  const toggleDisplay = (type: 'MarketPrice' | 'OraclePrice') => {
+    if (type === 'MarketPrice') {
+      marketPriceDisplay
+        ? setMarketPriceDisplay(false)
+        : setMarketPriceDisplay(true);
+    }
+    if (type === 'OraclePrice') {
+      oraclePriceDisplay
+        ? setOraclePriceDisplay(false)
+        : setOraclePriceDisplay(true);
+    }
+  };
   return (
     <div ref={containerRef} className='w-full h-[85%]'>
       <div className='flex justify-between flex-col md:flex-row md:items-center gap-2 md:gap-0 mt-2 mb-6 md:mr-3'>
@@ -52,9 +67,29 @@ export const Chart = ({ marketPriceData, oraclePriceData }: ChartProps) => {
           )}
           <p className=' text-sm font-semibold'>{chosenMarket?.name} Chart</p>
         </div>
-        <div className='flex items-center gap-1.5 ml-1 md:ml-0'>
-          <div className='w-[11px] h-[11px] rounded-full bg-[#4ECB7D]'></div>
-          <p className='text-xs'>- Market price</p>
+        <div className='flex items-center gap-4'>
+          <div className='flex items-center gap-1.5 ml-1 md:ml-0'>
+            <input
+              disabled={marketPriceDisplay && !oraclePriceDisplay}
+              type='checkbox'
+              checked={marketPriceDisplay}
+              onClick={() => toggleDisplay('MarketPrice')}
+            />
+
+            <p className='text-xs'>Market Price</p>
+            <div className='w-[11px] h-[11px] rounded-full bg-[#4ECB7D]'></div>
+          </div>
+          <div className='flex items-center gap-1.5 ml-1 md:ml-0'>
+            <input
+              disabled={oraclePriceDisplay && !marketPriceDisplay}
+              type='checkbox'
+              checked={oraclePriceDisplay}
+              onClick={() => toggleDisplay('OraclePrice')}
+            />
+
+            <p className='text-xs'>Oracle Price</p>
+            <div className='w-[11px] h-[11px] rounded-full bg-white'></div>
+          </div>
         </div>
       </div>
 
@@ -88,11 +123,11 @@ export const Chart = ({ marketPriceData, oraclePriceData }: ChartProps) => {
             },
           }}
         >
-          {marketPriceData.length > 0 && (
+          {marketPriceData.length > 0 && marketPriceDisplay && (
             <LineSeries data={marketPriceData} reactive color={'#4ECB7D'} />
           )}
-          {oraclePriceData.length > 0 && (
-            <LineSeries data={oraclePriceData} reactive color={'#ffc0cb'} />
+          {oraclePriceData.length > 0 && oraclePriceDisplay && (
+            <LineSeries data={oraclePriceData} reactive color={'white'} />
           )}
         </ChartComponent>
       )}

--- a/components/Market/TradingHub/TradingHub.tsx
+++ b/components/Market/TradingHub/TradingHub.tsx
@@ -11,8 +11,14 @@ import { useQuery } from '@apollo/client';
 
 import { UTCTimestamp } from 'lightweight-charts';
 import { TradingHubChart } from './TradingHubChart/TradingHubChart';
-import { MARKET_PRICE_FEED_QUERY } from '@/requests/queries';
-import { MarketPriceChartResponse } from '@/types/chartTypes';
+import {
+  MARKET_PRICE_FEED_QUERY,
+  ORACLE_PRICE_FEED_QUERY,
+} from '@/requests/queries';
+import {
+  MarketPriceChartResponse,
+  OraclePriceChartResponse,
+} from '@/types/chartTypes';
 
 const tabs = ['chart', 'positions', 'orders', 'history'] as const;
 export type TradingHubStateType = (typeof tabs)[number];
@@ -33,14 +39,27 @@ export const TradingHub = () => {
 
   const {
     data: marketPriceChartRes,
-    error,
-    loading,
+    error: marketPriceChartError,
+    loading: marketPriceChartLoading,
   } = useQuery<MarketPriceChartResponse>(MARKET_PRICE_FEED_QUERY, {
-    pollInterval: 5000,
+    pollInterval: 10000,
     variables: { marketId: selectedMarketId },
   });
 
-  const [chartData, setChartData] = useState<
+  const {
+    data: oraclePriceChartRes,
+    error: oraclePriceChartError,
+    loading: oraclePriceChartLoading,
+  } = useQuery<OraclePriceChartResponse>(ORACLE_PRICE_FEED_QUERY, {
+    pollInterval: 10000,
+    variables: { marketId: selectedMarketId },
+  });
+
+  const [marketPriceChartData, setMarketPriceChartData] = useState<
+    { time: UTCTimestamp; value: number }[]
+  >([]);
+
+  const [oraclePriceChartData, setOraclePriceChartData] = useState<
     { time: UTCTimestamp; value: number }[]
   >([]);
 
@@ -50,14 +69,26 @@ export const TradingHub = () => {
         time: (new Date(item.timestamp).getTime() / 1000) as UTCTimestamp,
         value: Number(item.createPrice),
       }));
-      setChartData(formattedData);
+      setMarketPriceChartData(formattedData);
     }
-  }, [marketPriceChartRes]);
+    if (oraclePriceChartRes?.historicalMarketPrices) {
+      const formattedData = oraclePriceChartRes.historicalMarketPrices.map(
+        (item) => ({
+          time: (new Date(item.timestamp).getTime() / 1000) as UTCTimestamp,
+          value: Number(item.price),
+        })
+      );
+      setOraclePriceChartData(formattedData);
+    }
+  }, [marketPriceChartRes, oraclePriceChartRes]);
 
   /*  */
 
   return (
-    <div className='h-[calc(100vh-166px)] lg:flex-1 lg:h-full border-[#444650] border rounded-[10px] flex flex-col bg-[#191B24]'>
+    <div
+      className='h-[calc(100vh-166px)] lg:flex-1 lg:h-full border-[#444650] border rounded-[10px] flex flex-col bg-[#191B24]'
+      onClick={() => console.log(oraclePriceChartData, marketPriceChartData)}
+    >
       <div className='flex-grow'>
         <div className='flex items-center justify-between px-2.5 pt-3 pb-2.5'>
           <div className='flex gap-1'>
@@ -77,7 +108,10 @@ export const TradingHub = () => {
         {address && <TradingHubContentContainer isAggregated={isAggregated} />}
         {tradingHubState === 'chart' && (
           <div className='w-full no-scrollbar'>
-            <TradingHubChart data={chartData} />
+            <TradingHubChart
+              marketPriceData={marketPriceChartData}
+              oraclePriceData={oraclePriceChartData}
+            />
           </div>
         )}
       </div>

--- a/components/Market/TradingHub/TradingHub.tsx
+++ b/components/Market/TradingHub/TradingHub.tsx
@@ -7,12 +7,12 @@ import { AggregatedPositionsCheckbox } from './TradingHubPositions/AggregatedPos
 import { tradingHubStateAtom } from '@/store/store';
 import { TradingHubFooter } from './TradingHubFooter';
 import { selectedMarketIdAtom } from '../Market';
-import { ChartFeedResponse } from '@/types/chartTypes';
 import { useQuery } from '@apollo/client';
-import { CHART_FEED_QUERY } from '@/requests/queries';
+
 import { UTCTimestamp } from 'lightweight-charts';
-import { ChatContainer } from './Chat/ChatContainer';
 import { TradingHubChart } from './TradingHubChart/TradingHubChart';
+import { MARKET_PRICE_FEED_QUERY } from '@/requests/queries';
+import { MarketPriceChartResponse } from '@/types/chartTypes';
 
 const tabs = ['chart', 'positions', 'orders', 'history'] as const;
 export type TradingHubStateType = (typeof tabs)[number];
@@ -32,10 +32,10 @@ export const TradingHub = () => {
   const [selectedMarketId] = useAtom(selectedMarketIdAtom);
 
   const {
-    data: chartRes,
+    data: marketPriceChartRes,
     error,
     loading,
-  } = useQuery<ChartFeedResponse>(CHART_FEED_QUERY, {
+  } = useQuery<MarketPriceChartResponse>(MARKET_PRICE_FEED_QUERY, {
     pollInterval: 5000,
     variables: { marketId: selectedMarketId },
   });
@@ -45,14 +45,14 @@ export const TradingHub = () => {
   >([]);
 
   useEffect(() => {
-    if (chartRes?.positions) {
-      const formattedData = chartRes.positions.map((item) => ({
+    if (marketPriceChartRes?.positions) {
+      const formattedData = marketPriceChartRes.positions.map((item) => ({
         time: (new Date(item.timestamp).getTime() / 1000) as UTCTimestamp,
         value: Number(item.createPrice),
       }));
       setChartData(formattedData);
     }
-  }, [chartRes]);
+  }, [marketPriceChartRes]);
 
   /*  */
 

--- a/components/Market/TradingHub/TradingHubChart/TradingHubChart.tsx
+++ b/components/Market/TradingHub/TradingHubChart/TradingHubChart.tsx
@@ -3,16 +3,23 @@ import { UTCTimestamp } from 'lightweight-charts';
 import React from 'react';
 
 interface TradingHubChartProps {
-  data: { time: UTCTimestamp; value: number }[];
+  marketPriceData: { time: UTCTimestamp; value: number }[];
+  oraclePriceData: { time: UTCTimestamp; value: number }[];
 }
 
-export const TradingHubChart = ({ data }: TradingHubChartProps) => {
+export const TradingHubChart = ({
+  marketPriceData,
+  oraclePriceData,
+}: TradingHubChartProps) => {
   return (
     <div
       className='w-full h-full  px-2.5  overflow-y-auto no-scrollbar'
       style={{ height: 'calc(100vh - 290px)' }}
     >
-      <Chart data={data} />
+      <Chart
+        marketPriceData={marketPriceData}
+        oraclePriceData={oraclePriceData}
+      />
     </div>
   );
 };

--- a/components/Market/TradingHub/TradingHubContentContainer.tsx
+++ b/components/Market/TradingHub/TradingHubContentContainer.tsx
@@ -1,5 +1,4 @@
 import {
-  CHART_FEED_QUERY,
   USER_HISTORY_QUERY,
   USER_OPEN_POSITIONS_QUERY,
   USER_ORDERS_QUERY,
@@ -24,7 +23,7 @@ import {
   tradingHubPositionsCountAtom,
   tradingHubStateAtom,
 } from '@/store/store';
-import { ChartFeedResponse } from '@/types/chartTypes';
+
 import { selectedMarketIdAtom } from '../Market';
 import { UTCTimestamp } from 'lightweight-charts';
 import { TradingHubChart } from './TradingHubChart/TradingHubChart';

--- a/requests/endpoints.ts
+++ b/requests/endpoints.ts
@@ -1,4 +1,4 @@
 export const httpEndpoint =
-  'https://bigshortbets.squids.live/bigsb-testnet/graphql';
+  'https://bigshortbets.squids.live/bigsb-testnet/v/v2/graphql';
 export const wsEndpoint =
-  'wss://bigshortbets.squids.live/bigsb-testnet/graphql';
+  'wss://bigshortbets.squids.live/bigsb-testnet/v/v2/graphql';

--- a/requests/queries.ts
+++ b/requests/queries.ts
@@ -193,12 +193,26 @@ export const LEADERBOARD_ELECTION_QUERY = gql`
   }
 `;
 
-/* Query for recent positions of given market*/
+/* Query for getting market price feed for chart*/
 
 export const MARKET_PRICE_FEED_QUERY = gql`
   query marketPriceFeed($marketId: String!) {
     positions(where: { market: { id_eq: $marketId } }, orderBy: timestamp_ASC) {
       createPrice
+      timestamp
+    }
+  }
+`;
+
+/* Query for getting oracle price feed for chart*/
+
+export const ORACLE_PRICE_FEED_QUERY = gql`
+  query oraclePriceFeed($marketId: String!) {
+    historicalMarketPrices(
+      where: { market: { id_eq: $marketId } }
+      orderBy: timestamp_ASC
+    ) {
+      price
       timestamp
     }
   }

--- a/requests/queries.ts
+++ b/requests/queries.ts
@@ -195,8 +195,8 @@ export const LEADERBOARD_ELECTION_QUERY = gql`
 
 /* Query for recent positions of given market*/
 
-export const CHART_FEED_QUERY = gql`
-  query chartFeed($marketId: String!) {
+export const MARKET_PRICE_FEED_QUERY = gql`
+  query marketPriceFeed($marketId: String!) {
     positions(where: { market: { id_eq: $marketId } }, orderBy: timestamp_ASC) {
       createPrice
       timestamp

--- a/types/chartTypes.ts
+++ b/types/chartTypes.ts
@@ -6,3 +6,12 @@ export interface MarketPriceChartType {
 export interface MarketPriceChartResponse {
   positions: MarketPriceChartType[];
 }
+
+export interface OraclePriceChartType {
+  price: bigint;
+  timestamp: string;
+}
+
+export interface OraclePriceChartResponse {
+  historicalMarketPrices: OraclePriceChartType[];
+}

--- a/types/chartTypes.ts
+++ b/types/chartTypes.ts
@@ -1,8 +1,8 @@
-export interface ChartFeedType {
+export interface MarketPriceChartType {
   createPrice: bigint;
   timestamp: string;
 }
 
-export interface ChartFeedResponse {
-  positions: ChartFeedType[];
+export interface MarketPriceChartResponse {
+  positions: MarketPriceChartType[];
 }


### PR DESCRIPTION
#122 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The chart component now supports displaying both market price and oracle price data through separate data sources.
  - Users can dynamically toggle the visibility of market and oracle price data on the chart using checkboxes.
  - Two new queries have been added for fetching market price and oracle price data.

- **Improvements**
  - Enhanced data fetching and state management for improved performance and user experience.
  - Updated rendering logic to accommodate more comprehensive data displays.

- **Chores**
  - Updated API endpoint URLs to reflect a new versioning structure.
  - Refactored query names for better clarity and specificity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->