### PR TITLE
139 add candle chart for oracle prices

### DIFF
--- a/components/Chart/Chart.tsx
+++ b/components/Chart/Chart.tsx
@@ -6,17 +6,20 @@ import React, { useEffect, useRef, useState } from 'react';
 import { selectedMarketIdAtom } from '../Market/Market';
 import { UTCTimestamp } from 'lightweight-charts';
 import {
+  CandlestickSeries,
   Chart as ChartComponent,
   LineSeries,
 } from 'lightweight-charts-react-wrapper';
 import { chosenMarketAtom } from '@/store/store';
 import Image from 'next/image';
+import { ConvertedOracleFeed } from '../Market/TradingHub/TradingHubChart/TradingHubChart';
 
 interface ChartProps {
   data: { time: UTCTimestamp; value: number }[];
+  oracleData: ConvertedOracleFeed[];
 }
 
-export const Chart = ({ data }: ChartProps) => {
+export const Chart = ({ data, oracleData }: ChartProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [chosenMarket] = useAtom(chosenMarketAtom);
@@ -69,9 +72,11 @@ export const Chart = ({ data }: ChartProps) => {
           }}
           layout={{ background: { color: '#191B24' }, textColor: 'white' }}
         >
-          {data.length > 0 && (
+          {/*   {data.length > 0 && (
             <LineSeries data={data} reactive color={'#4ECB7D'} />
-          )}
+           
+          )} */}
+          <CandlestickSeries data={oracleData} />
         </ChartComponent>
       )}
     </div>

--- a/components/Chart/Chart.tsx
+++ b/components/Chart/Chart.tsx
@@ -63,6 +63,12 @@ export const Chart = ({ data, oracleData }: ChartProps) => {
           <p className='text-xs'>- Market price</p>
         </div> */}
         <div className='flex items-center gap-4'>
+          {chartVariant === 'oracle' && (
+            <div className='flex items-center gap-1'>
+              <ChartIntervalTab value='1H' />
+              <ChartIntervalTab value='15M' />
+            </div>
+          )}
           <div className='flex items-center gap-1'>
             <ChartVariantTab
               value='oracle'
@@ -75,12 +81,6 @@ export const Chart = ({ data, oracleData }: ChartProps) => {
               setChosenChartVariant={setChartVariant}
             />
           </div>
-          {chartVariant === 'oracle' && (
-            <div className='flex items-center gap-1'>
-              <ChartIntervalTab value='1H' />
-              <ChartIntervalTab value='15M' />
-            </div>
-          )}
         </div>
       </div>
 

--- a/components/Chart/Chart.tsx
+++ b/components/Chart/Chart.tsx
@@ -1,9 +1,5 @@
-import { CHART_FEED_QUERY } from '@/requests/queries';
-import { ChartFeedResponse } from '@/types/chartTypes';
-import { useQuery } from '@apollo/client';
 import { useAtom } from 'jotai';
-import React, { useEffect, useRef, useState } from 'react';
-import { selectedMarketIdAtom } from '../Market/Market';
+import { useEffect, useRef, useState } from 'react';
 import { UTCTimestamp } from 'lightweight-charts';
 import {
   CandlestickSeries,
@@ -13,6 +9,9 @@ import {
 import { chosenMarketAtom } from '@/store/store';
 import Image from 'next/image';
 import { ConvertedOracleFeed } from '../Market/TradingHub/TradingHubChart/TradingHubChart';
+import { marketsData } from '@/data/marketsData';
+import { ChartIntervalTab } from './ChartIntervalTab';
+import { ChartVariantTab } from './ChartVariantTab';
 
 interface ChartProps {
   data: { time: UTCTimestamp; value: number }[];
@@ -23,6 +22,9 @@ export const Chart = ({ data, oracleData }: ChartProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [chosenMarket] = useAtom(chosenMarketAtom);
+  const [chartVariant, setChartVariant] = useState<'oracle' | 'market'>(
+    'oracle'
+  );
   useEffect(() => {
     const updateDimensions = () => {
       if (containerRef.current) {
@@ -56,14 +58,54 @@ export const Chart = ({ data, oracleData }: ChartProps) => {
           )}
           <p className=' text-sm font-semibold'>{chosenMarket?.name} Chart</p>
         </div>
-        <div className='flex items-center gap-1.5 ml-1 md:ml-0'>
+        {/* <div className='flex items-center gap-1.5 ml-1 md:ml-0'>
           <div className='w-[11px] h-[11px] rounded-full bg-[#4ECB7D]'></div>
           <p className='text-xs'>- Market price</p>
+        </div> */}
+        <div className='flex items-center gap-4'>
+          <div className='flex items-center gap-1'>
+            <ChartVariantTab
+              value='oracle'
+              chosenChartVariant={chartVariant}
+              setChosenChartVariant={setChartVariant}
+            />
+            <ChartVariantTab
+              value='market'
+              chosenChartVariant={chartVariant}
+              setChosenChartVariant={setChartVariant}
+            />
+          </div>
+          {chartVariant === 'oracle' && (
+            <div className='flex items-center gap-1'>
+              <ChartIntervalTab value='1H' />
+              <ChartIntervalTab value='15M' />
+            </div>
+          )}
         </div>
       </div>
 
       {dimensions.width > 0 && dimensions.height > 0 && (
         <ChartComponent
+          timeScale={{
+            timeVisible: true,
+            secondsVisible: true,
+            tickMarkFormatter: (time: any, tickMarkType: any, locale: any) => {
+              const date = new Date(time * 1000);
+              const hours = date.getHours().toString().padStart(2, '0');
+              const minutes = date.getMinutes().toString().padStart(2, '0');
+              const seconds = date.getSeconds().toString().padStart(2, '0');
+
+              if (tickMarkType === 'second') {
+                return `${hours}:${minutes}:${seconds}`;
+              } else if (tickMarkType === 'minute') {
+                return `${hours}:${minutes}`;
+              } else if (tickMarkType === 'hour') {
+                return `${hours}:00`;
+              } else {
+                return date.toLocaleDateString(locale);
+              }
+            },
+          }}
           width={dimensions.width}
           height={dimensions.height}
           grid={{
@@ -72,11 +114,12 @@ export const Chart = ({ data, oracleData }: ChartProps) => {
           }}
           layout={{ background: { color: '#191B24' }, textColor: 'white' }}
         >
-          {/*   {data.length > 0 && (
+          {data.length > 0 && chartVariant === 'market' && (
             <LineSeries data={data} reactive color={'#4ECB7D'} />
-           
-          )} */}
-          <CandlestickSeries data={oracleData} />
+          )}
+          {marketsData.length > 0 && chartVariant === 'oracle' && (
+            <CandlestickSeries data={oracleData} reactive />
+          )}
         </ChartComponent>
       )}
     </div>

--- a/components/Chart/ChartIntervalTab.tsx
+++ b/components/Chart/ChartIntervalTab.tsx
@@ -1,0 +1,22 @@
+import { chartIntervalAtom } from '@/store/store';
+import { useAtom } from 'jotai';
+import React from 'react';
+
+interface ChartIntervalTabProps {
+  value: '1H' | '15M';
+}
+
+export const ChartIntervalTab = ({ value }: ChartIntervalTabProps) => {
+  const [chartInterval, setChartInterval] = useAtom(chartIntervalAtom);
+  const isActive = value === chartInterval;
+  return (
+    <button
+      className={` rounded-lg flex items-center justify-center text-[11px] font-semibold py-1 px-2 ${
+        isActive ? 'bg-[#444650]' : 'bg-[#23252E] text-tetriary'
+      }`}
+      onClick={() => setChartInterval(value)}
+    >
+      {value}
+    </button>
+  );
+};

--- a/components/Chart/ChartVariantTab.tsx
+++ b/components/Chart/ChartVariantTab.tsx
@@ -1,0 +1,25 @@
+import { Dispatch, SetStateAction } from 'react';
+
+interface ChartVariantTabProps {
+  value: 'oracle' | 'market';
+  chosenChartVariant: 'oracle' | 'market';
+  setChosenChartVariant: Dispatch<SetStateAction<'oracle' | 'market'>>;
+}
+
+export const ChartVariantTab = ({
+  value,
+  chosenChartVariant,
+  setChosenChartVariant,
+}: ChartVariantTabProps) => {
+  const isActive = value === chosenChartVariant;
+  return (
+    <button
+      className={` rounded-lg capitalize flex items-center justify-center text-[11px] font-semibold py-1 px-2 ${
+        isActive ? 'bg-[#444650]' : 'bg-[#23252E] text-tetriary'
+      }`}
+      onClick={() => setChosenChartVariant(value)}
+    >
+      {value}
+    </button>
+  );
+};

--- a/components/Market/TradingHub/TradingHub.tsx
+++ b/components/Market/TradingHub/TradingHub.tsx
@@ -4,12 +4,20 @@ import { useAccount } from 'wagmi';
 import { TradingHubTab } from './TradingHubTab';
 import { TradingHubContentContainer } from './TradingHubContentContainer';
 import { AggregatedPositionsCheckbox } from './TradingHubPositions/AggregatedPositionsCheckbox';
-import { tradingHubStateAtom } from '@/store/store';
+import { chartIntervalAtom, tradingHubStateAtom } from '@/store/store';
 import { TradingHubFooter } from './TradingHubFooter';
 import { selectedMarketIdAtom } from '../Market';
-import { CandleFeed1HResponse, ChartFeedResponse } from '@/types/chartTypes';
+import {
+  OracleFeed1HResponse,
+  ChartFeedResponse,
+  OracleFeed15MinResponse,
+} from '@/types/chartTypes';
 import { useQuery } from '@apollo/client';
-import { CHART_FEED_QUERY, ORACLE_CHART_1H_QUERY } from '@/requests/queries';
+import {
+  CHART_FEED_QUERY,
+  ORACLE_CHART_15MIN_QUERY,
+  ORACLE_CHART_1H_QUERY,
+} from '@/requests/queries';
 import { UTCTimestamp } from 'lightweight-charts';
 import { ChatContainer } from './Chat/ChatContainer';
 import { TradingHubChart } from './TradingHubChart/TradingHubChart';
@@ -22,6 +30,7 @@ export const TradingHub = () => {
 
   const [tradingHubState] = useAtom(tradingHubStateAtom);
   const [isAggregated, setIsAggregated] = useState<boolean>(true);
+  const [chartInterval] = useAtom(chartIntervalAtom);
 
   const toggleIsAggregated = () => {
     setIsAggregated(!isAggregated);
@@ -31,19 +40,25 @@ export const TradingHub = () => {
 
   const [selectedMarketId] = useAtom(selectedMarketIdAtom);
 
-  const {
-    data: chartRes,
-    error,
-    loading,
-  } = useQuery<ChartFeedResponse>(CHART_FEED_QUERY, {
+  const { data: chartRes } = useQuery<ChartFeedResponse>(CHART_FEED_QUERY, {
     pollInterval: 5000,
     variables: { marketId: selectedMarketId },
   });
 
-  const { data: candleRes } = useQuery<CandleFeed1HResponse>(
+  const { data: oracleRes1H } = useQuery<OracleFeed1HResponse>(
     ORACLE_CHART_1H_QUERY,
     {
-      pollInterval: 5000,
+      pollInterval: 10000,
+      /*  skip: chartInterval != '1H', */
+      variables: { marketId: selectedMarketId },
+    }
+  );
+
+  const { data: oracleRes15Min } = useQuery<OracleFeed15MinResponse>(
+    ORACLE_CHART_15MIN_QUERY,
+    {
+      pollInterval: 10000,
+      /* skip: chartInterval != '15M', */
       variables: { marketId: selectedMarketId },
     }
   );
@@ -70,6 +85,15 @@ export const TradingHub = () => {
     }
   }, [chartRes]);
 
+  const oracleData =
+    chartInterval === '15M'
+      ? oracleRes15Min?.oracleChartFeed15Mins
+      : oracleRes1H?.oracleChartFeed1Hs;
+
+  useEffect(() => {
+    console.log(oracleData);
+  }, [oracleData]);
+
   /*  */
 
   return (
@@ -93,8 +117,8 @@ export const TradingHub = () => {
         {address && <TradingHubContentContainer isAggregated={isAggregated} />}
         {tradingHubState === 'chart' && (
           <div className='w-full no-scrollbar'>
-            {candleRes && (
-              <TradingHubChart data={chartData} oracleRes={candleRes} />
+            {oracleData && (
+              <TradingHubChart data={chartData} oracleData={oracleData} />
             )}
           </div>
         )}

--- a/components/Market/TradingHub/TradingHub.tsx
+++ b/components/Market/TradingHub/TradingHub.tsx
@@ -7,9 +7,9 @@ import { AggregatedPositionsCheckbox } from './TradingHubPositions/AggregatedPos
 import { tradingHubStateAtom } from '@/store/store';
 import { TradingHubFooter } from './TradingHubFooter';
 import { selectedMarketIdAtom } from '../Market';
-import { ChartFeedResponse } from '@/types/chartTypes';
+import { CandleFeed1HResponse, ChartFeedResponse } from '@/types/chartTypes';
 import { useQuery } from '@apollo/client';
-import { CHART_FEED_QUERY } from '@/requests/queries';
+import { CHART_FEED_QUERY, ORACLE_CHART_1H_QUERY } from '@/requests/queries';
 import { UTCTimestamp } from 'lightweight-charts';
 import { ChatContainer } from './Chat/ChatContainer';
 import { TradingHubChart } from './TradingHubChart/TradingHubChart';
@@ -39,6 +39,14 @@ export const TradingHub = () => {
     pollInterval: 5000,
     variables: { marketId: selectedMarketId },
   });
+
+  const { data: candleRes } = useQuery<CandleFeed1HResponse>(
+    ORACLE_CHART_1H_QUERY,
+    {
+      pollInterval: 5000,
+      variables: { marketId: selectedMarketId },
+    }
+  );
 
   const [chartData, setChartData] = useState<
     { time: UTCTimestamp; value: number }[]
@@ -85,7 +93,9 @@ export const TradingHub = () => {
         {address && <TradingHubContentContainer isAggregated={isAggregated} />}
         {tradingHubState === 'chart' && (
           <div className='w-full no-scrollbar'>
-            <TradingHubChart data={chartData} />
+            {candleRes && (
+              <TradingHubChart data={chartData} oracleRes={candleRes} />
+            )}
           </div>
         )}
       </div>

--- a/components/Market/TradingHub/TradingHubChart/TradingHubChart.tsx
+++ b/components/Market/TradingHub/TradingHubChart/TradingHubChart.tsx
@@ -1,15 +1,42 @@
 import { Chart } from '@/components/Chart/Chart';
+import { CandleFeed1HResponse } from '@/types/chartTypes';
+import { format } from 'date-fns';
 import { UTCTimestamp } from 'lightweight-charts';
 import React from 'react';
 
 interface TradingHubChartProps {
   data: { time: UTCTimestamp; value: number }[];
+  oracleRes: CandleFeed1HResponse;
 }
 
-export const TradingHubChart = ({ data }: TradingHubChartProps) => {
+export interface ConvertedOracleFeed {
+  open: number;
+  high: number;
+  close: number;
+  low: number;
+  time: UTCTimestamp;
+}
+
+export const TradingHubChart = ({ data, oracleRes }: TradingHubChartProps) => {
+  const converted: ConvertedOracleFeed[] = oracleRes.oracleChartFeed1Hs.map(
+    ({ openPrice, highPrice, closePrice, timestamp, lowPrice }) => {
+      const converted = Number(timestamp) / 1000;
+
+      return {
+        open: Number(openPrice),
+        high: Number(highPrice),
+        close: Number(closePrice),
+        low: Number(lowPrice),
+        time: converted as UTCTimestamp,
+      };
+    }
+  );
   return (
-    <div className='w-full   px-2.5  overflow-y-auto no-scrollbar h-[calc(100vh-290px)] md:h-[calc(100vh-230px)]'>
-      <Chart data={data} />
+    <div
+      className='w-full   px-2.5  overflow-y-auto no-scrollbar h-[calc(100vh-290px)] md:h-[calc(100vh-230px)]'
+      onClick={() => console.log(converted)}
+    >
+      <Chart data={data} oracleData={converted} />
     </div>
   );
 };

--- a/components/Market/TradingHub/TradingHubChart/TradingHubChart.tsx
+++ b/components/Market/TradingHub/TradingHubChart/TradingHubChart.tsx
@@ -1,12 +1,12 @@
 import { Chart } from '@/components/Chart/Chart';
-import { CandleFeed1HResponse } from '@/types/chartTypes';
+import { CandleFeed, OracleFeed1HResponse } from '@/types/chartTypes';
 import { format } from 'date-fns';
 import { UTCTimestamp } from 'lightweight-charts';
 import React from 'react';
 
 interface TradingHubChartProps {
   data: { time: UTCTimestamp; value: number }[];
-  oracleRes: CandleFeed1HResponse;
+  oracleData: CandleFeed[];
 }
 
 export interface ConvertedOracleFeed {
@@ -17,8 +17,8 @@ export interface ConvertedOracleFeed {
   time: UTCTimestamp;
 }
 
-export const TradingHubChart = ({ data, oracleRes }: TradingHubChartProps) => {
-  const converted: ConvertedOracleFeed[] = oracleRes.oracleChartFeed1Hs.map(
+export const TradingHubChart = ({ data, oracleData }: TradingHubChartProps) => {
+  const oracleDataConverted: ConvertedOracleFeed[] = oracleData.map(
     ({ openPrice, highPrice, closePrice, timestamp, lowPrice }) => {
       const converted = Number(timestamp) / 1000;
 
@@ -32,11 +32,8 @@ export const TradingHubChart = ({ data, oracleRes }: TradingHubChartProps) => {
     }
   );
   return (
-    <div
-      className='w-full   px-2.5  overflow-y-auto no-scrollbar h-[calc(100vh-290px)] md:h-[calc(100vh-230px)]'
-      onClick={() => console.log(converted)}
-    >
-      <Chart data={data} oracleData={converted} />
+    <div className='w-full   px-2.5  overflow-y-auto no-scrollbar h-[calc(100vh-290px)] md:h-[calc(100vh-230px)]'>
+      <Chart data={data} oracleData={oracleDataConverted} />
     </div>
   );
 };

--- a/requests/endpoints.ts
+++ b/requests/endpoints.ts
@@ -1,4 +1,4 @@
 export const httpEndpoint =
-  'https://bigshortbets.squids.live/bigsb-testnet/graphql';
+  'https://bigshortbets.squids.live/bigsb-testnet/v/v4/graphql';
 export const wsEndpoint =
-  'wss://bigshortbets.squids.live/bigsb-testnet/graphql';
+  'wss://bigshortbets.squids.live/bigsb-testnet/v/v4/graphql';

--- a/requests/queries.ts
+++ b/requests/queries.ts
@@ -220,11 +220,28 @@ export const CHART_FEED_QUERY = gql`
   }
 `;
 
-/* ORACLE 15 MIN FEED */
+/* ORACLE 1H FEED */
 
 export const ORACLE_CHART_1H_QUERY = gql`
   query oracleChartFeed1Hs($marketId: String!) {
     oracleChartFeed1Hs(
+      where: { market: { id_eq: $marketId } }
+      orderBy: timestamp_ASC
+    ) {
+      timestamp
+      openPrice
+      closePrice
+      lowPrice
+      highPrice
+    }
+  }
+`;
+
+/* ORACLE 15MIN FEED */
+
+export const ORACLE_CHART_15MIN_QUERY = gql`
+  query oracleChartFeed15Mins($marketId: String!) {
+    oracleChartFeed15Mins(
       where: { market: { id_eq: $marketId } }
       orderBy: timestamp_ASC
     ) {

--- a/requests/queries.ts
+++ b/requests/queries.ts
@@ -219,3 +219,20 @@ export const CHART_FEED_QUERY = gql`
     }
   }
 `;
+
+/* ORACLE 15 MIN FEED */
+
+export const ORACLE_CHART_1H_QUERY = gql`
+  query oracleChartFeed1Hs($marketId: String!) {
+    oracleChartFeed1Hs(
+      where: { market: { id_eq: $marketId } }
+      orderBy: timestamp_ASC
+    ) {
+      timestamp
+      openPrice
+      closePrice
+      lowPrice
+      highPrice
+    }
+  }
+`;

--- a/store/store.ts
+++ b/store/store.ts
@@ -21,3 +21,7 @@ export const tradingHubOrdersCountAtom = atom<number>(0);
 export const chosenInterlocutorAtom = atom<string>(
   '0x26C494d6526Df0c43c01480Ee07a870d4Eb0B647'
 );
+
+/* CHART INTERVAL */
+
+export const chartIntervalAtom = atom<'15M' | '1H'>('1H');

--- a/types/chartTypes.ts
+++ b/types/chartTypes.ts
@@ -15,6 +15,10 @@ export interface CandleFeed {
   timestamp: string;
 }
 
-export interface CandleFeed1HResponse {
+export interface OracleFeed1HResponse {
   oracleChartFeed1Hs: CandleFeed[];
+}
+
+export interface OracleFeed15MinResponse {
+  oracleChartFeed15Mins: CandleFeed[];
 }

--- a/types/chartTypes.ts
+++ b/types/chartTypes.ts
@@ -6,3 +6,15 @@ export interface ChartFeedType {
 export interface ChartFeedResponse {
   positions: ChartFeedType[];
 }
+
+export interface CandleFeed {
+  lowPrice: string;
+  highPrice: string;
+  openPrice: string;
+  closePrice: string;
+  timestamp: string;
+}
+
+export interface CandleFeed1HResponse {
+  oracleChartFeed1Hs: CandleFeed[];
+}


### PR DESCRIPTION
#139 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced the ability to toggle between ‘oracle’ and ‘market’ data in the chart.
  - Added support for chart interval selection, allowing users to choose between '1H' and '15M' intervals.
  - Implemented new queries to fetch detailed oracle chart data for different time intervals.

- **Enhancements**
  - Improved data visualization by restructuring the chart rendering logic for better user interactivity.
  - Updated time scale configuration for enhanced readability of the chart's time axis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->