### PR TITLE
Add explorer link to orders #36

### DIFF
--- a/components/Market/TradingHub/TradingHubOrders/TradingHubCompletedOrderItem.tsx
+++ b/components/Market/TradingHub/TradingHubOrders/TradingHubCompletedOrderItem.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { SideLabel } from '../SideLabel';
 import { useAtom } from 'jotai';
 import { selectedMarketIdAtom } from '../../Market';
+import { TbWorld } from 'react-icons/tb';
 
 interface TradingHubCompletedOrderItemProps {
   order: HistoryOrderType;
@@ -39,6 +40,15 @@ export const TradingHubCompletedOrderItem = ({
       <td>{Number(order.initialQuantity)}</td>
       {/* Close */}
       <td className='font-semibold'>{order.status}</td>
+      <td>
+        <a
+          href={`https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ftest-market.bigsb.network#/explorer/query/${order.blockHeight}`}
+          target='_blank'
+          className='text-medium text-tetriary'
+        >
+          <TbWorld />
+        </a>
+      </td>
     </tr>
   );
 };

--- a/components/Market/TradingHub/TradingHubOrders/TradingHubOrders.tsx
+++ b/components/Market/TradingHub/TradingHubOrders/TradingHubOrders.tsx
@@ -77,14 +77,13 @@ export const TradingHubOrders = ({
                         <th scope='col' className='px-6 py-3'>
                           Quantity
                         </th>
-                        {/* <th scope='col' className='px-6 py-3'>
-                        Type
-                      </th> */}
+
                         <th scope='col' className='px-6 py-3'></th>
                       </tr>
                     )}
                   </thead>
                   <tbody>
+                    {/* We should make Completed and Not completed as one component */}
                     {currentOrdersType === 'open' &&
                       openOrders.map((order, key) => (
                         <TradingHubOrdersItem order={order} key={key} />
@@ -116,17 +115,12 @@ export const TradingHubOrders = ({
                   <th className='font-normal'>Market</th>
                   <th className='font-normal'>Price</th>
                   <th className='font-normal'>Quantity</th>
-                  {/* <th className='font-normal'>Type</th> */}
 
                   <th className='pr-3'></th>
-                  {/* <th className="font-normal">Created</th>
-                  <th className="font-normal">Market</th>
-                  <th className="font-normal">Price</th>
-                
-                  <th className="pr-3"></th> */}
                 </tr>
               </thead>
               <tbody>
+                {/* We should make Completed and Not completed as one component */}
                 {currentOrdersType === 'open' &&
                   openOrders.map((order, key) => (
                     <TradingHubOrdersItem order={order} key={key} />

--- a/components/Market/TradingHub/TradingHubOrders/TradingHubOrdersItem.tsx
+++ b/components/Market/TradingHub/TradingHubOrders/TradingHubOrdersItem.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 import { fetchOrderCollateral } from '@/utils/fetchOrderCollateral';
 import { selectedMarketIdAtom } from '../../Market';
 import { useAtom } from 'jotai';
+import { TbWorld } from 'react-icons/tb';
 
 interface TradingHubOrdersItemProps {
   order: OrderType;
@@ -62,13 +63,22 @@ export const TradingHubOrdersItem = ({ order }: TradingHubOrdersItemProps) => {
       <td>{Number(order.quantity)}</td>
       {/*  <td>{order.type === 'CLOSING' ? 'Closing order' : 'Opening order'}</td> */}
       {/* Close */}
-      <td className=' text-right pr-3 '>
-        <button
-          className={`font-bold text-xs text-[#D26D6C] transition ease-in-out hover:text-[#C53F3A] duration-300`}
-          onClick={() => writeCancelOrder()}
-        >
-          CANCEL
-        </button>
+      <td className=' text-right pr-3'>
+        <div className='flex items-center justify-end space-x-4'>
+          <a
+            href={`https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ftest-market.bigsb.network#/explorer/query/${order.blockHeight}`}
+            target='_blank'
+            className='text-medium text-tetriary'
+          >
+            <TbWorld />
+          </a>
+          <button
+            className={`font-bold text-xs text-[#D26D6C] transition ease-in-out hover:text-[#C53F3A] duration-300`}
+            onClick={() => writeCancelOrder()}
+          >
+            CANCEL
+          </button>
+        </div>
       </td>
     </tr>
   );

--- a/types/historyTypes.ts
+++ b/types/historyTypes.ts
@@ -1,6 +1,7 @@
 import { EnrichedMarketType } from './marketTypes';
 
 export interface HistoryOrderType {
+  blockHeight: string;
   timestamp: string;
   id: string;
   market: {

--- a/types/orderTypes.ts
+++ b/types/orderTypes.ts
@@ -10,6 +10,7 @@ export interface OrderType {
   side: 'LONG' | 'SHORT';
   quantity: BigInt;
   type: OrderTypeUnion;
+  blockHeight: string;
 }
 
 enum OrderTypeEnum {


### PR DESCRIPTION
#36 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a link in the completed orders section that directs users to a Polkadot explorer page for detailed block height information.
	- Enhanced user interface with a new icon for quick access to blockchain details alongside order action buttons.

- **Bug Fixes**
	- Removed unused "Type" column from the orders table to streamline the display.

- **Chores**
	- Added a new property `blockHeight` to order-related data structures to support the new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->